### PR TITLE
Dev/andres/master req

### DIFF
--- a/src/app/gui/components/service/service.component.ts
+++ b/src/app/gui/components/service/service.component.ts
@@ -79,31 +79,27 @@ export class ServiceComponent implements OnInit {
   }
 
 
-  ngOnInit() {
-    // Initialize the favorite state from localStorage
-    const favs = JSON.parse(localStorage.getItem('favoriteServices') || '[]');
-    this.isFavorite = favs.includes(this.service.id);
+  async ngOnInit() {
+    // Inicializa el estado de favorito desde la API
+    try {
+      const favs = await this.api.getFavorites();
+      this.isFavorite = favs.includes(this.service.id);
+    } catch {
+      this.isFavorite = false;
+    }
   }
 
-  toggleFavorite() {
+  async toggleFavorite() {
     this.isFavorite = !this.isFavorite;
-    // Persist in localStorage
-    let favs: string[] = [];
     try {
-      favs = JSON.parse(localStorage.getItem('favoriteServices') || '[]');
+      if (this.isFavorite) {
+        await this.api.addFavorite(this.service.id);
+      } else {
+        await this.api.removeFavorite(this.service.id);
+      }
     } catch {}
-    if (this.isFavorite) {
-      if (!favs.includes(this.service.id)) favs.push(this.service.id);
-    } else {
-      favs = favs.filter(id => id !== this.service.id);
-    }
-    localStorage.setItem('favoriteServices', JSON.stringify(favs));
     // Emit event so parent can react
     this.favoriteChanged.emit({serviceId: this.service.id, isFavorite: this.isFavorite});
-    // Refresh screen if added or removed from favorites
-    // if (this.isFavorite || !this.isFavorite) {
-    //   window.location.reload();
-    // }
   }
 
   getTransportIcon(transId: string) {

--- a/src/app/gui/components/service/service.component.ts
+++ b/src/app/gui/components/service/service.component.ts
@@ -80,23 +80,15 @@ export class ServiceComponent implements OnInit {
 
 
   async ngOnInit() {
-    // Inicializa el estado de favorito desde la API
-    try {
-      const favs = await this.api.getFavorites();
-      this.isFavorite = favs.includes(this.service.id);
-    } catch {
-      this.isFavorite = false;
-    }
+    // Initialize the favorite status from the service field
+    this.isFavorite = !!this.service.favorite;
   }
 
   async toggleFavorite() {
-    this.isFavorite = !this.isFavorite;
+    const action = this.isFavorite ? 'unfavorite' : 'favorite';
     try {
-      if (this.isFavorite) {
-        await this.api.addFavorite(this.service.id);
-      } else {
-        await this.api.removeFavorite(this.service.id);
-      }
+      await this.api.action(this.service.id, action);
+      this.isFavorite = !this.isFavorite;
     } catch {}
     // Emit event so parent can react
     this.favoriteChanged.emit({serviceId: this.service.id, isFavorite: this.isFavorite});

--- a/src/app/gui/components/services-group/services-group.component.html
+++ b/src/app/gui/components/services-group/services-group.component.html
@@ -10,7 +10,7 @@
     </mat-expansion-panel-header>
     <div class="services-group">
       @for (s of sortedServices; track s.id) {
-        <uds-service [service]="s" (favoriteChanged)="onFavoriteChanged($event)"></uds-service>
+        <uds-service [service]="s" (favoriteChanged)="$event && favoriteChanged.emit($event)"></uds-service>
       }
     </div>
   </mat-expansion-panel>

--- a/src/app/gui/components/services-group/services-group.component.ts
+++ b/src/app/gui/components/services-group/services-group.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, ChangeDetectorRef } from '@angular/core';
 import { JSONGroup, JSONService } from '../../../types/services';
 import { UDSApiService } from '../../../services/uds-api.service';
 
@@ -13,6 +13,8 @@ export class ServicesGroupComponent implements OnInit {
   @Input() services: JSONService[] = [];
   @Input() group: JSONGroup = {} as JSONGroup;
   @Input() expanded = false;
+
+  @Output() favoriteChanged = new EventEmitter<{serviceId: string, isFavorite: boolean}>();
 
   constructor(private api: UDSApiService, private cdr: ChangeDetectorRef) { }
 
@@ -49,10 +51,6 @@ export class ServicesGroupComponent implements OnInit {
   ngOnInit() {
   }
 
-  onFavoriteChanged(event: {serviceId: string, isFavorite: boolean}) {
-    // Forzar refresco de la vista
-    this.services = [...this.services];
-    this.cdr.detectChanges();
-  }
+    // Ya no es necesario manejar el evento aquí, se propaga al padre
 
 }

--- a/src/app/pages/services/services.component.html
+++ b/src/app/pages/services/services.component.html
@@ -5,7 +5,7 @@
 <div class="services-groups">
   <mat-accordion>
     @for (g of group; track g; let i = $index) {
-      <uds-services-group [services]="g.services" [group]="g.group" [expanded]="i===0"></uds-services-group>
+      <uds-services-group [services]="g.services" [group]="g.group" [expanded]="i===0" (favoriteChanged)="onFavoriteChanged($event)"></uds-services-group>
     }
   </mat-accordion>
 </div>

--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -43,24 +43,18 @@ export class ServicesComponent implements OnInit {
   }
 
     /**
-     * Updates the favorites list when the status of a service changes
+     * Updates the favorites list when favorite status changes
      */
     onFavoriteChanged(event: {serviceId: string, isFavorite: boolean}) {
-      this.api.getFavorites().then(favs => {
-        localStorage.setItem('favoriteServices', JSON.stringify(favs));
-        this.updateServices();
-      });
+      // Reloads the list of services from the backend to reflect changes to favorites
+      this.loadServices();
     }
 
   ngOnInit() {
     if (this.api.config.urls.launch) {
       this.api.logout();
     } else {
-      // First we get the favorites from the backend and then we load the services
-      this.api.getFavorites().then(favs => {
-        localStorage.setItem('favoriteServices', JSON.stringify(favs));
-        this.loadServices(); // Loads service related data
-      });
+      this.loadServices(); // Loads service related data
     }
   }
 
@@ -111,13 +105,11 @@ export class ServicesComponent implements OnInit {
   }
 
   private updateServices(filter: string = '') {
-    // Fill up groupedServices
+    // Group services and favorites using the backend 'favorite' field
     this.group = [];
     this.favoritesGroup = new GroupedServices(FAVORITES_GROUP);
 
-    let current: GroupedServices|null = null;
-    // Oalways get favorites from backend (synced to localStorage by ngOnInit and onFavoriteChanged)
-    const favs = JSON.parse(localStorage.getItem('favoriteServices') || '[]');
+    let current: GroupedServices | null = null;
 
     this.servicesInformation.services
       .filter(
@@ -139,8 +131,8 @@ export class ServicesComponent implements OnInit {
         return 0;
       })
       .forEach((element) => {
-        // Add to favorites if applicable
-        if (favs.includes(element.id)) {
+        // Add to favorites if 'favorite' field is true
+        if (element.favorite) {
           this.favoritesGroup.services.push(element);
         }
         // ALWAYS add to original group
@@ -155,7 +147,7 @@ export class ServicesComponent implements OnInit {
     if (current !== null) {
       this.group.push(current);
     }
-    // Insert favorites group at the top if you have services
+    // Insert favorite group at the beginning if there are favorites
     if (this.favoritesGroup.services.length > 0) {
       this.group.unshift(this.favoritesGroup);
     }

--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -42,6 +42,16 @@ export class ServicesComponent implements OnInit {
     this.updateServices(filter);
   }
 
+    /**
+     * Actualiza la lista de favoritos cuando cambia el estado de un servicio
+     */
+    onFavoriteChanged(event: {serviceId: string, isFavorite: boolean}) {
+      this.api.getFavorites().then(favs => {
+        localStorage.setItem('favoriteServices', JSON.stringify(favs));
+        this.updateServices();
+      });
+    }
+
   ngOnInit() {
     if (this.api.config.urls.launch) {
       this.api.logout();

--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -43,7 +43,7 @@ export class ServicesComponent implements OnInit {
   }
 
     /**
-     * Actualiza la lista de favoritos cuando cambia el estado de un servicio
+     * Updates the favorites list when the status of a service changes
      */
     onFavoriteChanged(event: {serviceId: string, isFavorite: boolean}) {
       this.api.getFavorites().then(favs => {
@@ -56,7 +56,11 @@ export class ServicesComponent implements OnInit {
     if (this.api.config.urls.launch) {
       this.api.logout();
     } else {
-      this.loadServices(); // Loads service related data
+      // First we get the favorites from the backend and then we load the services
+      this.api.getFavorites().then(favs => {
+        localStorage.setItem('favoriteServices', JSON.stringify(favs));
+        this.loadServices(); // Loads service related data
+      });
     }
   }
 
@@ -112,6 +116,7 @@ export class ServicesComponent implements OnInit {
     this.favoritesGroup = new GroupedServices(FAVORITES_GROUP);
 
     let current: GroupedServices|null = null;
+    // Oalways get favorites from backend (synced to localStorage by ngOnInit and onFavoriteChanged)
     const favs = JSON.parse(localStorage.getItem('favoriteServices') || '[]');
 
     this.servicesInformation.services

--- a/src/app/services/uds-api.service.ts
+++ b/src/app/services/uds-api.service.ts
@@ -100,7 +100,7 @@ export class UDSApiService implements UDSApiServiceType {
   }
 
   /* Services resetter */
-  async action(action: string, serviceId: string): Promise<JSONService> {
+  async action(serviceId: string, action: string): Promise<JSONService> {
     const actionURL = this.config.urls.action.replace('param1', serviceId).replace('param2', action);
     return toPromise(this.http.get<JSONService>(actionURL));
   }
@@ -245,26 +245,5 @@ export class UDSApiService implements UDSApiServiceType {
   eval(data: string): void {
     // eslint-disable-next-line no-eval
     EVAL_FNC(data);
-  }
-
-  /** Favoritos: obtiene lista de favoritos del usuario */
-  getFavorites(): Promise<string[]> {
-    return this.http.get<{favorites: string[]}>(`/api/user/favorites/`).pipe(
-      timeout(TIMEOUT)
-    ).toPromise().then(res => res ? res.favorites : []);
-  }
-
-  /** Favoritos: añade un favorito */
-  addFavorite(serviceId: string): Promise<any> {
-    return this.http.post(`/api/user/favorites/`, { service_id: serviceId }).pipe(
-      timeout(TIMEOUT)
-    ).toPromise();
-  }
-
-  /** Favoritos: elimina un favorito */
-  removeFavorite(serviceId: string): Promise<any> {
-    return this.http.delete(`/api/user/favorites/${serviceId}/`).pipe(
-      timeout(TIMEOUT)
-    ).toPromise();
   }
 }

--- a/src/app/services/uds-api.service.ts
+++ b/src/app/services/uds-api.service.ts
@@ -246,4 +246,25 @@ export class UDSApiService implements UDSApiServiceType {
     // eslint-disable-next-line no-eval
     EVAL_FNC(data);
   }
+
+  /** Favoritos: obtiene lista de favoritos del usuario */
+  getFavorites(): Promise<string[]> {
+    return this.http.get<{favorites: string[]}>(`/api/user/favorites/`).pipe(
+      timeout(TIMEOUT)
+    ).toPromise().then(res => res ? res.favorites : []);
+  }
+
+  /** Favoritos: añade un favorito */
+  addFavorite(serviceId: string): Promise<any> {
+    return this.http.post(`/api/user/favorites/`, { service_id: serviceId }).pipe(
+      timeout(TIMEOUT)
+    ).toPromise();
+  }
+
+  /** Favoritos: elimina un favorito */
+  removeFavorite(serviceId: string): Promise<any> {
+    return this.http.delete(`/api/user/favorites/${serviceId}/`).pipe(
+      timeout(TIMEOUT)
+    ).toPromise();
+  }
 }

--- a/src/app/types/services.ts
+++ b/src/app/types/services.ts
@@ -36,6 +36,7 @@ export interface JSONService {
     custom_message_text: string|null;
     in_use: boolean;
     transports: JSONTransport[];
+    favorite: boolean;
 }
 
 export interface JSONServicesInformation {


### PR DESCRIPTION
This pull request refactors how favorite services are managed in the application, shifting from localStorage-based tracking to relying on the backend-provided `favorite` field for each service. This improves consistency across sessions and devices, and ensures favorite status is always up-to-date with the backend. The event handling for favorite changes is also streamlined, propagating changes up to the parent component to trigger a refresh of the services list.

**Backend-driven favorite status & event propagation:**

* The `favorite` status for each service is now determined by the backend-provided `favorite` field in the `JSONService` interface, replacing all localStorage logic. [[1]](diffhunk://#diff-e12cce384e31ed95cfe6e2341846ffe93f89b79f77960e007ad254a64b596ffdR39) [[2]](diffhunk://#diff-2906b6fdf0f3835c74c8bd07783c7cdb3de5a54e1134ad29cb583da1dee86c8fL82-L106) [[3]](diffhunk://#diff-5f2771ac65cd68c8e911f0f95719a2155d8ee9eea3a60445a0fc4878822b5c42L100-L105) [[4]](diffhunk://#diff-5f2771ac65cd68c8e911f0f95719a2155d8ee9eea3a60445a0fc4878822b5c42L127-R135)
* The `toggleFavorite` method in `ServiceComponent` now calls the backend API to update the favorite status, and updates the UI accordingly. [[1]](diffhunk://#diff-2906b6fdf0f3835c74c8bd07783c7cdb3de5a54e1134ad29cb583da1dee86c8fL82-L106) [[2]](diffhunk://#diff-7baa6f532a3a78506554fd3cb31d74189368dc1cb51455f2aba7e7646c35f472L103-R103)
* The favorite change event is now propagated up from `ServiceComponent` to `ServicesGroupComponent`, and finally to `ServicesComponent`, which reloads the services list to reflect the updated favorite status. [[1]](diffhunk://#diff-32b372e31009a2a65bce628b0301db96a5bc0f58f1e74d3f0f112713ffa3e3feL1-R1) [[2]](diffhunk://#diff-32b372e31009a2a65bce628b0301db96a5bc0f58f1e74d3f0f112713ffa3e3feR17-R18) [[3]](diffhunk://#diff-32b372e31009a2a65bce628b0301db96a5bc0f58f1e74d3f0f112713ffa3e3feL52-R54) [[4]](diffhunk://#diff-fc118c0c336e3c18f5a6cbe9d564db4695649332a1421182f8e5d1cb4ec28815L13-R13) [[5]](diffhunk://#diff-7c8dfd2af625369ff643215cf85e321705ba2a5a5e8880aa19814db6e56981e5L8-R8) [[6]](diffhunk://#diff-5f2771ac65cd68c8e911f0f95719a2155d8ee9eea3a60445a0fc4878822b5c42R45-R52)
* The grouping logic in `ServicesComponent` now uses the backend `favorite` field to determine which services belong in the favorites group, ensuring the UI matches backend state. [[1]](diffhunk://#diff-5f2771ac65cd68c8e911f0f95719a2155d8ee9eea3a60445a0fc4878822b5c42L100-L105) [[2]](diffhunk://#diff-5f2771ac65cd68c8e911f0f95719a2155d8ee9eea3a60445a0fc4878822b5c42L127-R135) [[3]](diffhunk://#diff-5f2771ac65cd68c8e911f0f95719a2155d8ee9eea3a60445a0fc4878822b5c42L143-R150)
* The API method signature for `action` in `UDSApiService` is updated to accept parameters in the correct order (`serviceId`, `action`).