### PR TITLE
Syncs favorite status on input changes

### DIFF
--- a/src/app/gui/components/service/service.component.ts
+++ b/src/app/gui/components/service/service.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, OnChanges, SimpleChanges, Input, Output, EventEmitter } from '@angular/core';
 import { JSONService, JSONTransport } from '../../../types/services';
 import { UDSApiService } from '../../../services/uds-api.service';
 
@@ -10,7 +10,7 @@ const MAX_NAME_LENGTH = 32;
     styleUrls: ['./service.component.scss'],
     standalone: false
 })
-export class ServiceComponent implements OnInit {
+export class ServiceComponent implements OnInit, OnChanges {
   @Input() service: JSONService = {} as JSONService;
 
   isFavorite: boolean = false;
@@ -79,8 +79,13 @@ export class ServiceComponent implements OnInit {
   }
 
 
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['service']) {
+      this.isFavorite = !!this.service.favorite;
+    }
+  }
+
   async ngOnInit() {
-    // Initialize the favorite status from the service field
     this.isFavorite = !!this.service.favorite;
   }
 


### PR DESCRIPTION
**The problem arises because if I have assigned services, meaning the service is in use, I can add it to favorites. But if that service has never been used or has no assigned services, it cannot be added to favorites.**

This pull request updates the `ServiceComponent` in the Angular application to improve how the favorite status is initialized and kept in sync with changes to the input `service`. The main enhancement is the implementation of the `OnChanges` lifecycle hook, which ensures that the component's `isFavorite` property accurately reflects the latest input data.

**Component lifecycle improvements:**

* Added the `OnChanges` interface to `ServiceComponent` and implemented the `ngOnChanges` method to update `isFavorite` whenever the `service` input changes. [[1]](diffhunk://#diff-2906b6fdf0f3835c74c8bd07783c7cdb3de5a54e1134ad29cb583da1dee86c8fL1-R1) [[2]](diffhunk://#diff-2906b6fdf0f3835c74c8bd07783c7cdb3de5a54e1134ad29cb583da1dee86c8fL13-R13) [[3]](diffhunk://#diff-2906b6fdf0f3835c74c8bd07783c7cdb3de5a54e1134ad29cb583da1dee86c8fR82-L83)

**Code quality:**

* Updated the import statement to include `OnChanges` and `SimpleChanges` from `@angular/core`.Ensures the favorite status updates when the input service changes, improving UI consistency for dynamically updated data.