### PR TITLE
GUI User improves

### DIFF
--- a/src/app/gui/components/background/background.component.ts
+++ b/src/app/gui/components/background/background.component.ts
@@ -100,6 +100,7 @@ export class BackgroundComponent implements OnInit, AfterViewInit, OnDestroy {
     this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
     this.time += 0.25;  // Global parameter to control wave movement speed
 
+    // Theme class is applied to <html> (see UDSApiService.applyTheme)
     const isDark = document.documentElement.classList.contains('dark-theme');
 
     // Base colors for the lines

--- a/src/app/pages/services/services.component.css
+++ b/src/app/pages/services/services.component.css
@@ -3,6 +3,7 @@
     padding-top: 30px; /* .content already adds margin-top 64px; 64+30 clears navbar (79) + ~15 margin */
     padding-left: 2%;
     padding-right: 2%;
+    --filter-w: 260px; /* reserved width for the absolute filter overlay */
 }
 
 @media only screen and (max-width: 744px) {
@@ -25,8 +26,21 @@
     position: absolute;
     top: 44px; /* On the tab bar: padding-top 30 + tabs margin-top 1rem */
     right: 2%;
+    width: var(--filter-w);
     z-index: 10;
     pointer-events: none; /* Let clicks pass through to the rest */
+}
+
+/* Make the filter input fill its reserved width (no internal gap) */
+.filter-top ::ng-deep .nav-input-field,
+.filter-bottom ::ng-deep .nav-input-field {
+    width: 100%;
+}
+
+/* Reserve space on the tab header so tabs and the overflow pagination arrows
+   never slide under the filter overlay (which would make them unclickable). */
+.services-groups ::ng-deep .modern-tabs.has-filter .mat-mdc-tab-header {
+    padding-right: calc(var(--filter-w) + 12px);
 }
 
 /* Push cards down: gap between filter/tabs and services */
@@ -45,9 +59,20 @@
         position: relative;
         top: 0;
         right: 0;
+        width: auto;
         margin-bottom: 1rem;
         pointer-events: auto;
         display: flex;
         justify-content: flex-end;
+    }
+
+    /* Filter flows above the tabs on mobile; no reserved space needed */
+    .services-groups ::ng-deep .modern-tabs.has-filter .mat-mdc-tab-header {
+        padding-right: 0;
+    }
+
+    .filter-top ::ng-deep .nav-input-field,
+    .filter-bottom ::ng-deep .nav-input-field {
+        width: auto;
     }
 }

--- a/src/app/pages/services/services.component.html
+++ b/src/app/pages/services/services.component.html
@@ -6,7 +6,8 @@
   }
 
   <div class="services-groups">
-    <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start" class="modern-tabs">
+    <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start" class="modern-tabs"
+      [class.has-filter]="servicesInformation.services.length >= api.config.min_for_filter">
       @for (g of group; track g; let i = $index) {
         <mat-tab>
           <ng-template mat-tab-label>

--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit, OnDestroy, ElementRef, NgZone } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 import { JSONServicesInformation, JSONGroup, JSONService } from '../../types/services';
 
@@ -27,7 +27,7 @@ class GroupedServices {
   styleUrls: ['./services.component.css'],
   standalone: false,
 })
-export class ServicesComponent implements OnInit {
+export class ServicesComponent implements OnInit, AfterViewInit, OnDestroy {
   servicesInformation: JSONServicesInformation = {
     autorun: false,
     services: [],
@@ -35,7 +35,45 @@ export class ServicesComponent implements OnInit {
 
   group: GroupedServices[] = [];
 
-  constructor(public api: UDSApiService) {}
+  constructor(public api: UDSApiService, private host: ElementRef<HTMLElement>, private zone: NgZone) {}
+
+  ngAfterViewInit() {
+    // Mouse wheel over the group tab bar scrolls the tab strip left/right,
+    // reusing Material's own pagination so the side arrow buttons keep working.
+    this.zone.runOutsideAngular(() => {
+      this.host.nativeElement.addEventListener('wheel', this.onTabsWheel, { passive: false });
+    });
+  }
+
+  ngOnDestroy() {
+    this.host.nativeElement.removeEventListener('wheel', this.onTabsWheel);
+  }
+
+  private onTabsWheel = (ev: WheelEvent) => {
+    const header = (ev.target as HTMLElement).closest('.mat-mdc-tab-header');
+    if (!header) {
+      return; // not over the group selector: let the page scroll normally
+    }
+
+    const delta =
+      Math.abs(ev.deltaX) > Math.abs(ev.deltaY) ? ev.deltaX : ev.deltaY;
+    if (delta === 0) {
+      return;
+    }
+
+    const dir = delta > 0 ? 'after' : 'before';
+    const btn = header.querySelector(
+      `.mat-mdc-tab-header-pagination-${dir}`,
+    ) as HTMLElement | null;
+
+    // No overflow (no pagination shown / nothing to scroll): don't hijack the wheel
+    if (!btn || btn.classList.contains('mat-mdc-tab-header-pagination-disabled')) {
+      return;
+    }
+
+    ev.preventDefault();
+    btn.click();
+  };
 
   update(filter: string) {
     this.updateServices(filter);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -66,7 +66,15 @@ body {
   font-size: $font-size;
   height: 100%;
   color: var(--text-primary);
+  background-color: transparent !important;
   transition: all 0.4s ease;
+}
+
+body {
+  background-image:
+    radial-gradient(at 0% 0%, rgba(70, 93, 156, 0.15) 0px, transparent 50%),
+    radial-gradient(at 100% 100%, rgba(75, 82, 102, 0.1) 0px, transparent 50%);
+  background-attachment: fixed;
 }
 
 /* App loading logo */
@@ -103,15 +111,15 @@ i.material-icons {
   --warning-color: #ff5252;
   --bg-button: linear-gradient(135deg, #3f51b5, #1a237e);
 
-  html,
+  /* Same approach as the admin GUI: keep html/body background-color transparent
+     (the dark base #0f111a comes from <html> via index.html, which paints below
+     the fixed z-index:-1 wave canvas) and put the gradients on <body> only, so
+     the animated waves stay visible in dark mode. */
   body {
-    background-color: var(--bg-surface);
     background-image:
       radial-gradient(at 0% 0%, rgba(67, 56, 202, 0.25) 0px, transparent 50%),
       radial-gradient(at 100% 100%, rgba(88, 28, 135, 0.2) 0px, transparent 50%),
       radial-gradient(at 50% 50%, var(--bg-accent) 0px, var(--bg-surface) 100%);
-    background-attachment: fixed; /* Pinned to viewport: no seam when scrolling */
-    background-repeat: no-repeat;
   }
 
   .menu .mat-mdc-icon-button {


### PR DESCRIPTION
This pull request improves the usability and appearance of the Services page, particularly the tab navigation and filter overlay. The main changes include making the filter overlay more robust and responsive, enhancing tab bar navigation with mouse wheel support, and refining the background styling for better theme compatibility and visual polish.

**Services page filter and tab usability improvements:**

- The filter overlay is now assigned a reserved width using a CSS variable (`--filter-w`), ensuring that the filter input always fills its intended space and that tabs and pagination arrows do not slide underneath the overlay, preventing unclickable elements. On mobile, the layout adapts so no space is reserved and the filter flows above the tabs. [[1]](diffhunk://#diff-a67e99239b52c5ef6c8e6ab20408c22fe7199f7dca66510d7beba7bb2652ef9aR6) [[2]](diffhunk://#diff-a67e99239b52c5ef6c8e6ab20408c22fe7199f7dca66510d7beba7bb2652ef9aR29-R45) [[3]](diffhunk://#diff-a67e99239b52c5ef6c8e6ab20408c22fe7199f7dca66510d7beba7bb2652ef9aR62-R77)
- The `mat-tab-group` in `services.component.html` now conditionally applies a `has-filter` class when the number of services exceeds a configured minimum, enabling the reserved space logic only when needed.

**Tab bar navigation enhancements:**

- The `ServicesComponent` now implements `AfterViewInit` and `OnDestroy` to add and clean up a mouse wheel event listener. When the user scrolls the mouse wheel over the tab bar, it scrolls the tab strip left or right by triggering Material's built-in pagination, improving navigation for users with many groups. [[1]](diffhunk://#diff-5f2771ac65cd68c8e911f0f95719a2155d8ee9eea3a60445a0fc4878822b5c42L1-R1) [[2]](diffhunk://#diff-5f2771ac65cd68c8e911f0f95719a2155d8ee9eea3a60445a0fc4878822b5c42L30-R76)

**Background and theming refinements:**

- The body background color is set to transparent, and background gradients are applied directly to the `<body>`, ensuring that the animated background waves remain visible in dark mode and that theming is consistent with the admin GUI. [[1]](diffhunk://#diff-23fad3928bf3e71585eb4a6e3b2ff72dae02c3ed5a44d2f0deb1d49f0cb3b1a3R69-R79) [[2]](diffhunk://#diff-23fad3928bf3e71585eb4a6e3b2ff72dae02c3ed5a44d2f0deb1d49f0cb3b1a3L106-L114)
- Added a clarifying comment in the background component noting that the theme class is applied to `<html>`, which is relevant for background rendering.