### PR TITLE
fix(user): POST + Django CSRF for state-changing WebAPI calls

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -5,7 +5,10 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-> 0.2% and not dead
-last 2 versions
-last 4 years
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Safari versions
+last 2 Edge versions
+last 2 Opera versions
 Firefox ESR
+not dead

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { LayoutModule } from '@angular/cdk/layout';
 import { NgModule } from '@angular/core';
 
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClient, withInterceptorsFromDi, withXsrfConfiguration } from '@angular/common/http';
 import { AppRoutingModule } from './modules/app-routing.module';
 
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -74,6 +74,10 @@ import { CredentialsModalComponent } from './gui/credentials-modal/credentials-m
         UDSApiService,
         UDSGuiService,
         BiometricService,
-        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClient(
+            withInterceptorsFromDi(),
+            // Django CSRF: cookie 'csrftoken' + header 'X-CSRFToken', not Angular's XSRF defaults
+            withXsrfConfiguration({ cookieName: 'csrftoken', headerName: 'X-CSRFToken' }),
+        ),
     ] })
 export class AppModule { }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,41 +43,40 @@ import { LauncherComponent } from './pages/launcher/launcher.component';
 import { FilterComponent } from './gui/components/filter/filter.component';
 import { CredentialsModalComponent } from './gui/credentials-modal/credentials-modal.component';
 
-
-@NgModule({ declarations: [
-        AppComponent,
-        NavbarComponent,
-        TranslateDirective,
-        LoginComponent,
-        ClientDownloadComponent,
-        ServicesComponent,
-        ServiceComponent,
-        ServicesGroupComponent,
-        ModalComponent,
-        CredentialsModalComponent,
-        SafeHtmlPipe,
-        FooterComponent,
-        ErrorComponent,
-        AboutComponent,
-        DownloadsComponent,
-        LauncherComponent,
-        StaffInfoComponent,
-        FilterComponent,
-        MfaComponent,
-        BackgroundComponent,
-    ],
-    bootstrap: [AppComponent], imports: [BrowserModule,
-        LayoutModule,
-        AppRoutingModule,
-        BrowserAnimationsModule,
-        AppMaterialModule], providers: [
-        UDSApiService,
-        UDSGuiService,
-        BiometricService,
-        provideHttpClient(
-            withInterceptorsFromDi(),
-            // Django CSRF: cookie 'csrftoken' + header 'X-CSRFToken', not Angular's XSRF defaults
-            withXsrfConfiguration({ cookieName: 'csrftoken', headerName: 'X-CSRFToken' }),
-        ),
-    ] })
-export class AppModule { }
+@NgModule({
+  declarations: [
+    AppComponent,
+    NavbarComponent,
+    TranslateDirective,
+    LoginComponent,
+    ClientDownloadComponent,
+    ServicesComponent,
+    ServiceComponent,
+    ServicesGroupComponent,
+    ModalComponent,
+    CredentialsModalComponent,
+    SafeHtmlPipe,
+    FooterComponent,
+    ErrorComponent,
+    AboutComponent,
+    DownloadsComponent,
+    LauncherComponent,
+    StaffInfoComponent,
+    FilterComponent,
+    MfaComponent,
+    BackgroundComponent,
+  ],
+  bootstrap: [AppComponent],
+  imports: [BrowserModule, LayoutModule, AppRoutingModule, BrowserAnimationsModule, AppMaterialModule],
+  providers: [
+    UDSApiService,
+    UDSGuiService,
+    BiometricService,
+    provideHttpClient(
+      withInterceptorsFromDi(),
+      // Django CSRF: cookie 'csrftoken' + header 'X-CSRFToken', not Angular's XSRF defaults
+      withXsrfConfiguration({ cookieName: 'csrftoken', headerName: 'X-CSRFToken' }),
+    ),
+  ],
+})
+export class AppModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { LayoutModule } from '@angular/cdk/layout';
-import { NgModule } from '@angular/core';
+import { NgModule, provideZoneChangeDetection } from '@angular/core';
 
 import { provideHttpClient, withInterceptorsFromDi, withXsrfConfiguration } from '@angular/common/http';
 import { AppRoutingModule } from './modules/app-routing.module';
@@ -43,41 +43,41 @@ import { LauncherComponent } from './pages/launcher/launcher.component';
 import { FilterComponent } from './gui/components/filter/filter.component';
 import { CredentialsModalComponent } from './gui/credentials-modal/credentials-modal.component';
 
-
-@NgModule({ declarations: [
-        AppComponent,
-        NavbarComponent,
-        TranslateDirective,
-        LoginComponent,
-        ClientDownloadComponent,
-        ServicesComponent,
-        ServiceComponent,
-        ServicesGroupComponent,
-        ModalComponent,
-        CredentialsModalComponent,
-        SafeHtmlPipe,
-        FooterComponent,
-        ErrorComponent,
-        AboutComponent,
-        DownloadsComponent,
-        LauncherComponent,
-        StaffInfoComponent,
-        FilterComponent,
-        MfaComponent,
-        BackgroundComponent,
-    ],
-    bootstrap: [AppComponent], imports: [BrowserModule,
-        LayoutModule,
-        AppRoutingModule,
-        BrowserAnimationsModule,
-        AppMaterialModule], providers: [
-        UDSApiService,
-        UDSGuiService,
-        BiometricService,
-        provideHttpClient(
-            withInterceptorsFromDi(),
-            // Django CSRF: cookie 'csrftoken' + header 'X-CSRFToken', not Angular's XSRF defaults
-            withXsrfConfiguration({ cookieName: 'csrftoken', headerName: 'X-CSRFToken' }),
-        ),
-    ] })
-export class AppModule { }
+@NgModule({
+  declarations: [
+    AppComponent,
+    NavbarComponent,
+    TranslateDirective,
+    LoginComponent,
+    ClientDownloadComponent,
+    ServicesComponent,
+    ServiceComponent,
+    ServicesGroupComponent,
+    ModalComponent,
+    CredentialsModalComponent,
+    SafeHtmlPipe,
+    FooterComponent,
+    ErrorComponent,
+    AboutComponent,
+    DownloadsComponent,
+    LauncherComponent,
+    StaffInfoComponent,
+    FilterComponent,
+    MfaComponent,
+    BackgroundComponent,
+  ],
+  bootstrap: [AppComponent],
+  imports: [BrowserModule, LayoutModule, AppRoutingModule, BrowserAnimationsModule, AppMaterialModule],
+  providers: [
+    provideZoneChangeDetection(),
+    UDSApiService,
+    UDSGuiService,
+    BiometricService,
+    provideHttpClient(
+      withInterceptorsFromDi(),
+      // Django CSRF: cookie 'csrftoken' + header 'X-CSRFToken', not Angular's XSRF defaults
+      withXsrfConfiguration({ cookieName: 'csrftoken', headerName: 'X-CSRFToken' }),
+    ),
+  ],
+})
+export class AppModule {}

--- a/src/app/services/uds-api.service.ts
+++ b/src/app/services/uds-api.service.ts
@@ -124,7 +124,7 @@ export class UDSApiService implements UDSApiServiceType {
   /* Client enabler */
   async enabler(serviceId: string, transportId: string): Promise<JSONEnabledService> {
     const enabler = this.config.urls.enabler.replace('param1', serviceId).replace('param2', transportId);
-    return toPromise(this.http.get<JSONEnabledService>(enabler));
+    return toPromise(this.http.post<JSONEnabledService>(enabler, null));
   }
 
   /* Check userService status */
@@ -136,11 +136,11 @@ export class UDSApiService implements UDSApiServiceType {
   /* Services resetter */
   async action(action: string, serviceId: string): Promise<JSONService> {
     const actionURL = this.config.urls.action.replace('param1', serviceId).replace('param2', action);
-    return toPromise(this.http.get<JSONService>(actionURL));
+    return toPromise(this.http.post<JSONService>(actionURL, null));
   }
 
   async transportUrl(url: string): Promise<JSONTransportURLService> {
-    return toPromise(this.http.get<JSONTransportURLService>(url));
+    return toPromise(this.http.post<JSONTransportURLService>(url, null));
   }
 
   async updateTransportTicket(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { enableProdMode, provideZoneChangeDetection } from '@angular/core';
+import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
@@ -9,5 +9,5 @@ if (environment.production) {
 }
 
 platformBrowserDynamic()
-  .bootstrapModule(AppModule, { applicationProviders: [provideZoneChangeDetection()] })
+  .bootstrapModule(AppModule)
   .catch((err) => console.log(err));


### PR DESCRIPTION
## What changes

3 state-changing WebAPI calls in `src/app/services/uds-api.service.ts` now go by POST (with Django CSRF) instead of GET:

- `enabler(serviceId, transportId)` — POST (enables a service)
- `action(action, serviceId)` — POST (release / reset / favorite / unfavorite)
- `transportUrl(url)` — POST (transport ticket/link)

`status` and other reads stay on GET.

### Supporting changes

- `src/app/app.module.ts`:
  - Add `provideZoneChangeDetection()` in the providers (Angular 21 requires it; was misplaced in `main.ts`).
  - Configure `withXsrfConfiguration({ cookieName: 'csrftoken', headerName: 'X-CSRFToken' })` so the HttpClient sends Django's CSRF header on POST/PUT/DELETE.
- `src/main.ts`: drop the misplaced `provideZoneChangeDetection` import (it's a provider, not a bootstrap call).
- `.browserslistrc`: drop `> 0.2% and not dead`, `last 4 years`, `last 2 versions` — they were pulling Chrome 103 into the esbuild target. Replaced with `last 2 <browser> versions` per browser + `not dead`.

## Why

Mirrors the broker's `fix-user-webapi-get-post` PR (the one that adds `@require_POST` on the server side). The SPA was still sending GET, so on its own this PR does nothing useful. Together they close a state-mutation-via-GET footgun and prepare for the actor/client migration to POST.

The Angular/browserslist fixes were forced by the Angular 21 upgrade: without `provideZoneChangeDetection()` the app throws at bootstrap, and the old browserslist queries pin the esbuild target to Chrome 103, which the new HTTP client no longer accepts.

## Own diff

```
 .browserslistrc                     |  8 ++--
 src/app/app.module.ts               | 76 +++++++++++++++++++------------------
 src/app/services/uds-api.service.ts |  6 +--
 src/main.ts                         |  4 +-
 4 files changed, 50 insertions(+), 44 deletions(-)
```

## Coordinate with

- `VirtualCable/broker` PR `fix-user-webapi-get-post` — must be deployed together. A cached old SPA would start getting 405.
- `VirtualCable/broker` PR `feat-rest-dual-verb-compat` — if you prefer a dual-verb phase with `Deprecation`/`Sunset` instead of the clean POST cut, say so.

Pre-publish: 0 hits for `licen valid until|enterprise|secret|passwd|api_key|internal URLs|customer` in the diff.
