### PR TITLE
Fix storage availability check in the user interface

### DIFF
--- a/src/app/services/uds-api.service.ts
+++ b/src/app/services/uds-api.service.ts
@@ -263,13 +263,13 @@ export class UDSApiService implements UDSApiServiceType {
 
   // Storage related
   putOnStorage(key: string, value: string): void {
-    if (typeof Storage !== undefined) {
+    if (typeof Storage !== 'undefined') {
       localStorage.setItem(key, value);
     }
   }
 
   getFromStorage(key: string): string | null {
-    if (typeof Storage !== undefined) {
+    if (typeof Storage !== 'undefined') {
       return localStorage.getItem(key);
     } else {
       return null;


### PR DESCRIPTION
Same defect as in the administration interface: typeof Storage was compared against undefined instead of the string 'undefined'.