### PR TITLE
fix(login): stop the login page from overflowing the fold

### DIFF
--- a/src/app/pages/login/login.component.css
+++ b/src/app/pages/login/login.component.css
@@ -4,7 +4,10 @@
 	flex-flow: column wrap;
 	justify-content: center;
 	align-items: center;
-	min-height: 100vh;
+	/* The shell is not free: .content clears the fixed navbar with a 64px top
+	   margin and the footer block takes 3em (app.component.scss). A full 100vh
+	   here pushes the document past the window and leaves a dead scrollbar. */
+	min-height: calc(100vh - 64px - 3em);
 	padding-top: 50px;
 	padding-bottom: 40px;
 	box-sizing: border-box;

--- a/src/app/pages/login/login.component.layout.spec.ts
+++ b/src/app/pages/login/login.component.layout.spec.ts
@@ -1,0 +1,97 @@
+import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LoginComponent } from './login.component';
+import { UDSApiService } from '../../services/uds-api.service';
+import { BiometricService } from '../../services/biometric.service';
+import { SafeHtmlPipe } from '../../helpers/safe-html.pipe';
+
+/**
+ * The login page must fit the viewport. The shell already spends 64px on the
+ * navbar offset and 3em on the footer block, so a login card asking for a full
+ * 100vh on top of that leaves the document taller than the window and the
+ * browser shows a scrollbar with nothing below the fold.
+ *
+ * The host reuses app.component.scss instead of copying the shell rules, so
+ * a change to the navbar offset or the footer box shows up here.
+ */
+@Component({
+  template: `
+    <div class="page">
+      <div class="content"><uds-login></uds-login></div>
+      <div class="footer"></div>
+    </div>
+  `,
+  styleUrls: ['../../app.component.scss'],
+  standalone: false,
+})
+class ShellHostComponent {}
+
+describe('LoginComponent page height', () => {
+  let fixture: ComponentFixture<ShellHostComponent>;
+
+  beforeEach(async () => {
+    const apiStub = jasmine.createSpyObj<UDSApiService>('UDSApiService', ['staticURL'], {
+      config: {
+        site_name: 'UDS',
+        site_information: '',
+        authenticators: [],
+        allow_biometric_auth: false,
+        urls: { login: '/uds/page/login' },
+      } as any,
+      errors: [],
+    });
+    (apiStub as any).csrfField = 'csrfmiddlewaretoken';
+    (apiStub as any).csrfToken = 'test-csrf-token-1234';
+    (apiStub as any).staticURL = (path: string) => `/uds/res/${path}`;
+
+    await TestBed.configureTestingModule({
+      declarations: [ShellHostComponent, LoginComponent, SafeHtmlPipe],
+      providers: [
+        { provide: UDSApiService, useValue: apiStub },
+        {
+          provide: BiometricService,
+          useValue: jasmine.createSpyObj('BiometricService', ['hasStoredData', 'clearCredentials']),
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ShellHostComponent);
+    fixture.detectChanges();
+  });
+
+  function box(selector: string): HTMLElement {
+    const el = document.querySelector(selector) as HTMLElement | null;
+    if (el === null) {
+      fail(`Expected ${selector} to be rendered`);
+    }
+    return el as HTMLElement;
+  }
+
+  /** Height the shell spends on the navbar offset and on the footer block. */
+  function reservedByShell(): number {
+    const content = box('.content');
+    const footer = box('.footer');
+    const footerStyle = getComputedStyle(footer);
+    return (
+      parseFloat(getComputedStyle(content).marginTop) +
+      footer.getBoundingClientRect().height +
+      parseFloat(footerStyle.marginTop) +
+      parseFloat(footerStyle.marginBottom)
+    );
+  }
+
+  /** Height the login card reserves for itself, whatever its content ends up being. */
+  function claimedByLogin(): number {
+    return parseFloat(getComputedStyle(box('.login-container')).minHeight);
+  }
+
+  it('leaves room for the navbar offset and the footer', () => {
+    const total = claimedByLogin() + reservedByShell();
+    expect(total).toBeLessThanOrEqual(
+      window.innerHeight,
+      `login reserves ${claimedByLogin()}px plus ${reservedByShell()}px of shell, ` +
+        `${total - window.innerHeight}px more than the ${window.innerHeight}px viewport`,
+    );
+  });
+});


### PR DESCRIPTION
Closes the login scroll that QA reported on the 24th: "haces scroll abajo o arriba, pero hay un scroll aquí".

The card asked for `min-height: 100vh`, but the shell already spends height around it: `.content` carries a 64px top margin to clear the fixed navbar, and the footer block takes 3em (`app.component.scss`). The document therefore came out 106px taller than the window, with nothing below the fold.

Measured in a 437px viewport: the card reserved 437px, the shell 106px, total 543px.

The fix reserves only what the shell leaves: `min-height: calc(100vh - 64px - 3em)`.

`login.component.layout.spec.ts` mounts the login inside the real shell (it reuses `app.component.scss` rather than copying the rules) and checks that what the card reserves plus what the shell spends fits the viewport. Verified both ways:

- without the fix: `Expected 543 to be less than or equal 437, 'login reserves 437px plus 106px of shell, 106px more than the 437px viewport'`
- with the fix: `TOTAL: 5 SUCCESS`

`ng build --configuration production` is green and `ng lint` reports the same single pre-existing error as master (the unused `TIMEOUT` in `uds-api.service.ts`), nothing new.

One thing worth knowing when testing it: a window shorter than the form itself will still scroll, and that is correct. What goes away is the fixed 106px that showed up on every screen size.
