### PR TITLE
refactor(app): move the portal to inject() and cap requests at 10s

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, HostListener, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from './services/uds-api.service';
 
 @Component({
@@ -9,9 +9,9 @@ import { UDSApiService } from './services/uds-api.service';
   standalone: false,
 })
 export class AppComponent implements OnInit {
-  title = 'UDS';
+  private api = inject(UDSApiService);
 
-  constructor(private api: UDSApiService) {}
+  title = 'UDS';
 
   @HostListener('document:keydown', ['$event'])
   handleKeyboardEvent(event: KeyboardEvent) {

--- a/src/app/gui/components/background/background.component.ts
+++ b/src/app/gui/components/background/background.component.ts
@@ -7,6 +7,7 @@ import {
   ViewChild,
   AfterViewInit,
   ChangeDetectionStrategy,
+  inject,
 } from '@angular/core';
 import { UDSApiService } from '../../../services/uds-api.service';
 
@@ -40,14 +41,14 @@ interface SilkWave {
   standalone: false,
 })
 export class BackgroundComponent implements OnInit, AfterViewInit, OnDestroy {
+  private api = inject(UDSApiService);
+
   @ViewChild('backgroundThumbnail', { static: false }) canvasRef!: ElementRef<HTMLCanvasElement>;
 
   private ctx!: CanvasRenderingContext2D | null;
   private waves: SilkWave[] = [];
   private animationFrameId?: number;
   private time = 0;
-
-  constructor(private api: UDSApiService) {}
 
   get isEnabled(): boolean {
     return this.api.config.allow_animated_backgrounds === true;

--- a/src/app/gui/components/service/service.component.ts
+++ b/src/app/gui/components/service/service.component.ts
@@ -7,6 +7,7 @@ import {
   Output,
   EventEmitter,
   ChangeDetectionStrategy,
+  inject,
 } from '@angular/core';
 import { JSONService, JSONTransport } from '../../../types/services';
 import { UDSApiService } from '../../../services/uds-api.service';
@@ -21,6 +22,8 @@ const MAX_NAME_LENGTH = 32;
   standalone: false,
 })
 export class ServiceComponent implements OnInit, OnChanges {
+  private api = inject(UDSApiService);
+
   @Input() service: JSONService = {} as JSONService;
 
   isFavorite: boolean = false;
@@ -30,8 +33,6 @@ export class ServiceComponent implements OnInit, OnChanges {
     // Change 'favoriteEnabled' to the actual property name in config if different
     return (this.api.config as any).enable_favorite_services === true;
   }
-
-  constructor(private api: UDSApiService) {}
 
   get serviceImage() {
     return this.api.galleryImageURL(this.service.imageId);

--- a/src/app/gui/components/services-group/services-group.component.ts
+++ b/src/app/gui/components/services-group/services-group.component.ts
@@ -6,6 +6,7 @@ import {
   EventEmitter,
   ChangeDetectorRef,
   ChangeDetectionStrategy,
+  inject,
 } from '@angular/core';
 import { JSONGroup, JSONService } from '../../../types/services';
 import { UDSApiService } from '../../../services/uds-api.service';
@@ -18,17 +19,15 @@ import { UDSApiService } from '../../../services/uds-api.service';
   standalone: false,
 })
 export class ServicesGroupComponent implements OnInit {
+  private api = inject(UDSApiService);
+  private cdr = inject(ChangeDetectorRef);
+
   @Input() services: JSONService[] = [];
   @Input() group: JSONGroup = {} as JSONGroup;
   @Input() expanded = false;
   @Input() enableFavoriteServices = true;
 
   @Output() favoriteChanged = new EventEmitter<{ serviceId: string; isFavorite: boolean }>();
-
-  constructor(
-    private api: UDSApiService,
-    private cdr: ChangeDetectorRef,
-  ) {}
 
   get groupImage() {
     return this.api.galleryImageURL(this.group.imageUuid);

--- a/src/app/gui/components/staff-info/staff-info.component.ts
+++ b/src/app/gui/components/staff-info/staff-info.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from '../../../services/uds-api.service';
 
 @Component({
@@ -9,7 +9,7 @@ import { UDSApiService } from '../../../services/uds-api.service';
   standalone: false,
 })
 export class StaffInfoComponent implements OnInit {
-  constructor(public api: UDSApiService) {}
+  api = inject(UDSApiService);
 
   ngOnInit(): void {}
 }

--- a/src/app/gui/credentials-modal/credentials-modal.component.ts
+++ b/src/app/gui/credentials-modal/credentials-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
@@ -9,6 +9,11 @@ import { MAT_DIALOG_DATA } from '@angular/material/dialog';
   standalone: false,
 })
 export class CredentialsModalComponent {
+  data = inject<{
+    username: string;
+    domain: string;
+  }>(MAT_DIALOG_DATA);
+
   username: string;
   password: string;
   domain: string;
@@ -18,7 +23,9 @@ export class CredentialsModalComponent {
     domain: django.gettext('Domain'),
   };
 
-  constructor(@Inject(MAT_DIALOG_DATA) public data: { username: string; domain: string }) {
+  constructor() {
+    const data = this.data;
+
     this.username = data.username;
     this.domain = data.domain;
     this.password = '';

--- a/src/app/gui/footer/footer.component.ts
+++ b/src/app/gui/footer/footer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 
 @Component({
@@ -9,7 +9,7 @@ import { UDSApiService } from '../../services/uds-api.service';
   standalone: false,
 })
 export class FooterComponent implements OnInit {
-  constructor(public api: UDSApiService) {}
+  api = inject(UDSApiService);
 
   ngOnInit() {}
 }

--- a/src/app/gui/modal/modal.component.ts
+++ b/src/app/gui/modal/modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { interval } from 'rxjs';
 import { Future } from '../../helpers/tools';
@@ -26,15 +26,11 @@ export interface ModalData {
   standalone: false,
 })
 export class ModalComponent implements OnInit {
+  dialogRef = inject<MatDialogRef<ModalComponent>>(MatDialogRef);
+  data = inject<ModalData>(MAT_DIALOG_DATA);
+
   extra = '';
   yesno: Future<boolean> = new Future<boolean>();
-
-  constructor(
-    public dialogRef: MatDialogRef<ModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: ModalData,
-  ) {
-    // Notifies on case of yes or not to subscriber
-  }
 
   resolveAndClose(value: boolean): void {
     this.yesno.resolve(value);

--- a/src/app/gui/modal/modal.component.ts
+++ b/src/app/gui/modal/modal.component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 import { Component, OnInit, Inject, ChangeDetectionStrategy } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { interval } from 'rxjs';

--- a/src/app/gui/navbar/navbar.component.ts
+++ b/src/app/gui/navbar/navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 import { Lang } from '../../types/config';
 
@@ -10,11 +10,15 @@ import { Lang } from '../../types/config';
   standalone: false,
 })
 export class NavbarComponent implements OnInit {
+  api = inject(UDSApiService);
+
   lang: Lang = {} as Lang; // Current language
   langs: Lang[] = []; // Available languages
   style = ''; // Empty on start
 
-  constructor(public api: UDSApiService) {
+  constructor() {
+    const api = this.api;
+
     const lang = api.config.language;
     // Add "non current lang" to list
     this.langs = [];

--- a/src/app/helpers/safe-html.pipe.ts
+++ b/src/app/helpers/safe-html.pipe.ts
@@ -1,12 +1,12 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 @Pipe({
-    name: 'safeHtml',
-    standalone: false
+  name: 'safeHtml',
+  standalone: false,
 })
 export class SafeHtmlPipe implements PipeTransform {
-  constructor(private sanitizer: DomSanitizer) {}
+  private sanitizer = inject(DomSanitizer);
 
   transform(value: any, _args?: any): any {
     // Allow html, disallow scripts, onclick, etc.
@@ -14,7 +14,7 @@ export class SafeHtmlPipe implements PipeTransform {
     value = value.replace(/<\s*script\s*/gi, '');
     // Remove if exists any javascript event
     // Remove all events: 'onclick', 'onmouseover', 'onmouseout',
-    // 'onmousemove', 'onmouseenter', 'onmouseleave', 'onmouseup', 
+    // 'onmousemove', 'onmouseenter', 'onmouseleave', 'onmouseup',
     // 'onmousedown', 'onkeyup', 'onkeydown', 'onkeypress', 'onkeydown',
     // 'onkeypress', 'onkeyup', 'onchange', 'onfocus', 'onblur', 'onload', 'onunload', 'onabort', 'onerror', 'onresize', 'onscroll'
     value = value.replace(/(on|(on\w+\s*))=\s*['"]?[^'"]*['"]?/gi, '');
@@ -24,5 +24,4 @@ export class SafeHtmlPipe implements PipeTransform {
 
     return this.sanitizer.bypassSecurityTrustHtml(value);
   }
-
 }

--- a/src/app/helpers/safe-html.pipe.ts
+++ b/src/app/helpers/safe-html.pipe.ts
@@ -13,7 +13,6 @@ export class SafeHtmlPipe implements PipeTransform {
     // if appears "script" tag, remove it and all following characters (to avoid XSS)
     value = value.replace(/<\s*script\s*/gi, '');
     // Remove if exists any javascript event
-    // eslint-disable-next-line max-len
     // Remove all events: 'onclick', 'onmouseover', 'onmouseout',
     // 'onmousemove', 'onmouseenter', 'onmouseleave', 'onmouseup', 
     // 'onmousedown', 'onkeyup', 'onkeydown', 'onkeypress', 'onkeydown',

--- a/src/app/helpers/tools.ts
+++ b/src/app/helpers/tools.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { timeout } from 'rxjs/operators';
 import { firstValueFrom, Observable } from 'rxjs';
 

--- a/src/app/helpers/translate.directive.ts
+++ b/src/app/helpers/translate.directive.ts
@@ -1,18 +1,16 @@
-import { Directive, OnInit, ElementRef } from '@angular/core';
+import { Directive, OnInit, ElementRef, inject } from '@angular/core';
 
 @Directive({
-    // eslint-disable-next-line @angular-eslint/directive-selector
-    selector: 'uds-translate',
-    standalone: false
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: 'uds-translate',
+  standalone: false,
 })
 export class TranslateDirective implements OnInit {
-
-  constructor(private el: ElementRef) { }
+  private el = inject(ElementRef);
 
   ngOnInit() {
     // Simply substitute innter html with translation
 
     this.el.nativeElement.innerHTML = django.gettext(this.el.nativeElement.innerHTML.trim());
   }
-
 }

--- a/src/app/modules/auth.guard.ts
+++ b/src/app/modules/auth.guard.ts
@@ -1,18 +1,18 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { UDSApiService } from '../services/uds-api.service';
 import { Observable } from 'rxjs';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AuthGuard implements CanActivate {
-  constructor(private api: UDSApiService) {
-  }
+  private api = inject(UDSApiService);
 
   canActivate(
     _next: ActivatedRouteSnapshot,
-    _state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
+    _state: RouterStateSnapshot,
+  ): Observable<boolean> | Promise<boolean> | boolean {
     // Redirect, if not logged in, to login screen
     if (!this.api.user.isLogged) {
       this.api.router.navigate(['login']);

--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 
 @Component({
@@ -9,9 +9,9 @@ import { UDSApiService } from '../../services/uds-api.service';
   standalone: false,
 })
 export class AboutComponent implements OnInit {
-  year = new Date().getFullYear();
+  api = inject(UDSApiService);
 
-  constructor(public api: UDSApiService) {}
+  year = new Date().getFullYear();
 
   ngOnInit() {
     if (this.year < 2021) {

--- a/src/app/pages/client-download/client-download.component.ts
+++ b/src/app/pages/client-download/client-download.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 import { Downloadable } from '../../types/config';
 
@@ -10,7 +10,7 @@ import { Downloadable } from '../../types/config';
   standalone: false,
 })
 export class ClientDownloadComponent implements OnInit {
-  constructor(public api: UDSApiService) {}
+  api = inject(UDSApiService);
 
   ngOnInit() {}
 

--- a/src/app/pages/downloads/downloads.component.ts
+++ b/src/app/pages/downloads/downloads.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 import { Downloadable } from '../../types/config';
 
@@ -10,9 +10,9 @@ import { Downloadable } from '../../types/config';
   standalone: false,
 })
 export class DownloadsComponent implements OnInit {
-  actors: Downloadable[] = [];
+  api = inject(UDSApiService);
 
-  constructor(public api: UDSApiService) {}
+  actors: Downloadable[] = [];
 
   ngOnInit() {
     // Sort legacy actors to the end of the list

--- a/src/app/pages/error/error.component.ts
+++ b/src/app/pages/error/error.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { UDSApiService } from '../../services/uds-api.service';
 
@@ -10,13 +10,11 @@ import { UDSApiService } from '../../services/uds-api.service';
   standalone: false,
 })
 export class ErrorComponent implements OnInit {
+  api = inject(UDSApiService);
+  private route = inject(ActivatedRoute);
+
   error = '';
   returnUrl = '/';
-
-  constructor(
-    public api: UDSApiService,
-    private route: ActivatedRoute,
-  ) {}
 
   async ngOnInit() {
     await this.getError();

--- a/src/app/pages/launcher/launcher.component.ts
+++ b/src/app/pages/launcher/launcher.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 
 @Component({
@@ -9,7 +9,7 @@ import { UDSApiService } from '../../services/uds-api.service';
   standalone: false,
 })
 export class LauncherComponent implements OnInit {
-  constructor(public api: UDSApiService) {}
+  api = inject(UDSApiService);
 
   ngOnInit() {
     if (this.api.config.urls.launch) {

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 import { BiometricService } from '../../services/biometric.service';
 import { Authenticator } from '../../types/config';
@@ -11,16 +11,16 @@ import { Authenticator } from '../../types/config';
   standalone: false,
 })
 export class LoginComponent implements OnInit {
+  api = inject(UDSApiService);
+  biometric = inject(BiometricService);
+
   auths: Authenticator[];
   auth: HTMLInputElement = {} as HTMLInputElement;
   title = 'UDS Enterprise';
 
-  constructor(
-    public api: UDSApiService,
-    public biometric: BiometricService,
-  ) {
-    this.title = api.config.site_name;
-    this.auths = api.config.authenticators.slice(0);
+  constructor() {
+    this.title = this.api.config.site_name;
+    this.auths = this.api.config.authenticators.slice(0);
     // Sort array, so we can display it correctly
     this.auths.sort((a, b) => a.priority - b.priority);
   }

--- a/src/app/pages/mfa/mfa.component.ts
+++ b/src/app/pages/mfa/mfa.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, inject } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 
 @Component({
@@ -9,7 +9,7 @@ import { UDSApiService } from '../../services/uds-api.service';
   standalone: false,
 })
 export class MfaComponent implements OnInit {
-  constructor(public api: UDSApiService) {}
+  api = inject(UDSApiService);
 
   ngOnInit() {
     // We want to keep compatibility right now with previous UDS templates, so we

--- a/src/app/pages/services/services.component.ts
+++ b/src/app/pages/services/services.component.ts
@@ -6,6 +6,7 @@ import {
   ElementRef,
   NgZone,
   ChangeDetectionStrategy,
+  inject,
 } from '@angular/core';
 import { UDSApiService } from '../../services/uds-api.service';
 import { JSONServicesInformation, JSONGroup, JSONService } from '../../types/services';
@@ -37,18 +38,16 @@ class GroupedServices {
   standalone: false,
 })
 export class ServicesComponent implements OnInit, AfterViewInit, OnDestroy {
+  api = inject(UDSApiService);
+  private host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private zone = inject(NgZone);
+
   servicesInformation: JSONServicesInformation = {
     autorun: false,
     services: [],
   };
 
   group: GroupedServices[] = [];
-
-  constructor(
-    public api: UDSApiService,
-    private host: ElementRef<HTMLElement>,
-    private zone: NgZone,
-  ) {}
 
   ngAfterViewInit() {
     // Mouse wheel over the group tab bar scrolls the tab strip left/right,

--- a/src/app/services/uds-api.service.spec.ts
+++ b/src/app/services/uds-api.service.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TimeoutError } from 'rxjs';
+
+import { UDSApiService } from './uds-api.service';
+import { UDSGuiService } from './uds-gui.service';
+
+/**
+ * Verifies that every call to the broker is capped by the TIMEOUT constant of
+ * the service. Without the cap a request the broker never answers leaves its
+ * promise pending forever and the portal stays waiting with no way out.
+ */
+describe('UDSApiService request timeout', () => {
+  const SERVICES_URL = '/uds/page/services/data';
+  const TIMEOUT = 10000;
+
+  let service: UDSApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    (window as any).udsData = {
+      profile: { user: 'test', role: 'user', admin: false },
+      config: { urls: { services: SERVICES_URL }, launcher_wait_time: 5000 },
+    };
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [
+        UDSApiService,
+        { provide: UDSGuiService, useValue: jasmine.createSpyObj('UDSGuiService', ['alert', 'yesno']) },
+      ],
+    });
+
+    service = TestBed.inject(UDSApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  it('gives up on a request the broker never answers', fakeAsync(() => {
+    let failure: unknown;
+    service.getServicesInformation().catch((error) => (failure = error));
+
+    httpMock.expectOne(SERVICES_URL);
+    tick(TIMEOUT);
+
+    expect(failure).toBeInstanceOf(TimeoutError);
+  }));
+
+  it('keeps the answer when it arrives before the cap', fakeAsync(() => {
+    let information: unknown;
+    service.getServicesInformation().then((data) => (information = data));
+
+    httpMock.expectOne(SERVICES_URL).flush({ services: [] });
+    tick(TIMEOUT);
+
+    expect(information).toEqual({ services: [] } as any);
+  }));
+});

--- a/src/app/services/uds-api.service.ts
+++ b/src/app/services/uds-api.service.ts
@@ -123,23 +123,23 @@ export class UDSApiService implements UDSApiServiceType {
   /* Client enabler */
   async enabler(serviceId: string, transportId: string): Promise<JSONEnabledService> {
     const enabler = this.config.urls.enabler.replace('param1', serviceId).replace('param2', transportId);
-    return toPromise(this.http.post<JSONEnabledService>(enabler, null));
+    return toPromise(this.http.post<JSONEnabledService>(enabler, null), TIMEOUT);
   }
 
   /* Check userService status */
   async status(serviceId: string, transportId: string): Promise<JSONStatusService> {
     const status = this.config.urls.status.replace('param1', serviceId).replace('param2', transportId);
-    return toPromise(this.http.get<JSONStatusService>(status));
+    return toPromise(this.http.get<JSONStatusService>(status), TIMEOUT);
   }
 
   /* Services resetter */
   async action(action: string, serviceId: string): Promise<JSONService> {
     const actionURL = this.config.urls.action.replace('param1', serviceId).replace('param2', action);
-    return toPromise(this.http.post<JSONService>(actionURL, null));
+    return toPromise(this.http.post<JSONService>(actionURL, null), TIMEOUT);
   }
 
   async transportUrl(url: string): Promise<JSONTransportURLService> {
-    return toPromise(this.http.post<JSONTransportURLService>(url, null));
+    return toPromise(this.http.post<JSONTransportURLService>(url, null), TIMEOUT);
   }
 
   async updateTransportTicket(
@@ -156,6 +156,7 @@ export class UDSApiService implements UDSApiServiceType {
         password,
         domain,
       }),
+      TIMEOUT,
     );
   }
 
@@ -180,14 +181,14 @@ export class UDSApiService implements UDSApiServiceType {
    * Gets services information
    */
   async getServicesInformation(): Promise<JSONServicesInformation> {
-    return toPromise(this.http.get<JSONServicesInformation>(this.config.urls.services));
+    return toPromise(this.http.get<JSONServicesInformation>(this.config.urls.services), TIMEOUT);
   }
 
   /**
    * Gets error string from a code
    */
   async getErrorInformation(errorCode: string): Promise<JSONErrorInformation> {
-    return toPromise(this.http.get<JSONErrorInformation>(this.config.urls.error.replace('9999', errorCode)));
+    return toPromise(this.http.get<JSONErrorInformation>(this.config.urls.error.replace('9999', errorCode)), TIMEOUT);
   }
 
   /**
@@ -246,7 +247,7 @@ export class UDSApiService implements UDSApiServiceType {
    * @returns  Observable
    */
   async getAuthCustomJavascript(authId: string): Promise<string> {
-    return toPromise(this.http.get(this.config.urls.custom_auth + authId, { responseType: 'text' }));
+    return toPromise(this.http.get(this.config.urls.custom_auth + authId, { responseType: 'text' }), TIMEOUT);
   }
 
   // Switch dark/light theme

--- a/src/app/services/uds-api.service.ts
+++ b/src/app/services/uds-api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { User, UDSConfig, Downloadable, Info } from '../types/config';
@@ -25,6 +25,10 @@ const TIMEOUT = 10000;
 
 @Injectable()
 export class UDSApiService implements UDSApiServiceType {
+  private http = inject(HttpClient);
+  gui = inject(UDSGuiService);
+  router = inject(Router);
+
   readonly user: User;
   transportsWindow: Window | null = null;
   plugin: Plugin;
@@ -34,11 +38,7 @@ export class UDSApiService implements UDSApiServiceType {
     return this._isDarkTheme;
   }
 
-  constructor(
-    private http: HttpClient,
-    public gui: UDSGuiService,
-    public router: Router,
-  ) {
+  constructor() {
     this.user = new User(udsData.profile);
     this.plugin = new Plugin(this);
   }

--- a/src/app/services/uds-gui.service.ts
+++ b/src/app/services/uds-gui.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { ModalComponent, DialogType } from '../gui/modal/modal.component';
 import { CredentialsModalComponent } from '../gui/credentials-modal/credentials-modal.component';
@@ -7,13 +7,9 @@ import { toPromise } from '../helpers/tools';
 
 @Injectable()
 export class UDSGuiService {
-  constructor(public dialog: MatDialog) {}
+  dialog = inject(MatDialog);
 
-  async alert(
-    title: string,
-    message: string,
-    autoclose = 0,
-  ): Promise<MatDialogRef<ModalComponent>> {
+  async alert(title: string, message: string, autoclose = 0): Promise<MatDialogRef<ModalComponent>> {
     const width = window.innerWidth < 800 ? '80%' : '40%';
     const dialogRef = this.dialog.open(ModalComponent, {
       width,
@@ -41,7 +37,10 @@ export class UDSGuiService {
     return dialogRef.componentInstance.yesno;
   }
 
-  askCredentials(username: string, domain: string): Promise<{username: string; password: string; domain: string; success: boolean}> {
+  askCredentials(
+    username: string,
+    domain: string,
+  ): Promise<{ username: string; password: string; domain: string; success: boolean }> {
     const dialogRef = this.dialog.open(CredentialsModalComponent, {
       data: {
         username,

--- a/src/app/types/config.ts
+++ b/src/app/types/config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 // Types definition for configuration from js
 
 export interface Lang {

--- a/src/app/types/services.ts
+++ b/src/app/types/services.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 // Types definition for services json
 
 export interface JSONGroup {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,6 +1,5 @@
 /* SystemJS module definition */
 /// <reference types="node" />
-// eslint-disable-next-line no-var
 declare var module: NodeModule;
 interface NodeModule {
   id: string;


### PR DESCRIPTION
Constructor injection swapped for inject() across services, pages, dialogs, guard, pipe and directive, and the TIMEOUT constant now caps the eight calls to the broker so a silent server no longer leaves a promise pending.